### PR TITLE
Update IDs to handle negative integers and strings

### DIFF
--- a/src/req.rs
+++ b/src/req.rs
@@ -29,9 +29,27 @@ pub enum Version {
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Id {
-    String(String),
+    String(Arc<String>),
     Number(i64),
     Null,
+}
+
+impl From<&str> for Id {
+    fn from(id: &str) -> Self {
+        Id::String(Arc::new(id.to_string()))
+    }
+}
+
+impl From<String> for Id {
+    fn from(id: String) -> Self {
+        Id::String(Arc::new(id))
+    }
+}
+
+impl From<i64> for Id {
+    fn from(id: i64) -> Self {
+        Id::Number(id)
+    }
 }
 
 impl Request {
@@ -114,7 +132,8 @@ mod test {
             "id": "string identifier"
         }"#;
         let req = serde_json::from_str::<Request>(req_str).unwrap();
-        assert_eq!(req.id(), Id::String("string identifier".to_string()));
+        assert_eq!(req.id(), Id::from("string identifier"));
+        assert_eq!(req.id(), Id::from(String::from("string identifier")));
     }
 
     #[test]
@@ -125,7 +144,7 @@ mod test {
             "id": -1234
         }"#;
         let req = serde_json::from_str::<Request>(req_str).unwrap();
-        assert_eq!(req.id(), Id::Number(-1234));
+        assert_eq!(req.id(), Id::from(-1234));
     }
 
     #[test]


### PR DESCRIPTION
This brings the library in line with the [specification for IDs](https://www.jsonrpc.org/specification#request_object).

Specifically, it updates the ID to be one of a String, Number, or NULL value, and to return the exact value in the response as was  passed in the Request (i.e. the Response will include `"id": null` if the request did).  JSON supports negative integers, so the ID also now supports this.

Note that when a Request does not contain an "id", it should not be treated as if it contained `"id": null`.  Instead the [specification says the following](https://www.jsonrpc.org/specification#notification):

> A Notification is a Request object without an "id" member.

and 

> The Server MUST NOT reply to a Notification, including those that are within a batch request.

As such, I believe making the `id` field non-optional in the `Request` struct makes sense.  If the crate were to be updated to handle Notifications, that might be best handled by having a separate `Notification` type which didn't contain an `id` member, rather than holding such a field as an optional member?

Finally, thanks for providing this crate!